### PR TITLE
Added first draft of cli

### DIFF
--- a/requirements/customer/cli.tex
+++ b/requirements/customer/cli.tex
@@ -56,8 +56,8 @@ If set to 0, no information is printed out.}
 \jacommand{add}
 {gpu, mount, name, priority, server, ram, threads}
 {Sends one or more job requests to the server.
-If targets are Docker containers the consists of simply running the container.
-If targets are configuration files with a specified terminal command the worker executes the given terminal command.
+If targets are Docker containers the job consists of simply running the container.
+If targets are configuration files with a specified terminal command the job consists of running the specified terminal command.
 Otherwise targets are interpreted as terminal commands}
 \jaoption{gpu}{g}{
 If set to true, informs the server that the job requires a gpu.

--- a/requirements/customer/cli.tex
+++ b/requirements/customer/cli.tex
@@ -1,15 +1,16 @@
 \newcommand{\jacommand}[3]{
-
-\textsc{\large{\textbf{#1}}}
+\textsc{\LARGE{\textbf{#1}}}
 \begin{itemize}
-\item[\textbf{Options:}] #2
-\item[\textbf{Effect:}] #3
+\item \textbf{Options:} #2
+\item \textbf{Effect:} #3
 \end{itemize}
 }
+\newcommand{\jaoptionheader}{\textsc{\textbf{Option descriptions:}}\newline\newline}
 \newcommand{\jaoption}[3]{
+\textbf{#1}
 \begin{itemize}
-\item[] \textbf{#1} (#2)
-\item[\textbf{Effect:}] #3
+\item \textbf{Short form:} #2
+\item \textbf{Effect:} #3
 \end{itemize}
 }
 \subsection{Command Line Interface}
@@ -59,6 +60,7 @@ If set to 0, no information is printed out.}
 If targets are Docker containers the job consists of simply running the container.
 If targets are configuration files with a specified terminal command the job consists of running the specified terminal command.
 Otherwise targets are interpreted as terminal commands}
+\jaoptionheader
 \jaoption{gpu}{g}{
 If set to true, informs the server that the job requires a gpu.
 If set to a string that can be interpreted as VRAM amount, informs the server that a GPU with this amount of VRAM is required for the job.
@@ -79,26 +81,20 @@ Defaults to localhost.}
 {If set to a string that can be interpreted as RAM amount, informs the server that this amount of RAM is required for the job.}
 \jaoption{threads}{t}
 {If set to an integer, informs the server that this number of threads is required for the job.}
-
-\jacommand{pause}{None}{Pauses the job with the specified name.}
-
 \jacommand{query}{user}
 {Prints out information on running/queued/past jobs (specified by target).
 In addition to the one below, options from add command can be used as constraints.}
+\jaoptionheader
 \jaoption{after}{a}{Only return jobs added after the given point in time.}
 \jaoption{before}{b}{Only return jobs added before the given point in time.}
 \jaoption{user}{u}{Filter query by user that added the job.}
-
-\jacommand{resume}{None}{Resumes the job with the specified name.}
-
 \jacommand{stop}{None}{Stops the job with the specified name.}
-
 \subsubsection{Server}
 \jacommand{start}{None}{Starts an instance of the JobAdder server.}
 \jacommand{stop}{None}{Stops instances of the JobAdder server.}
-
 \subsubsection{Worker Client}
 \jacommand{start}{server}{Starts an instance of the JobAdder worker client.}
+\jaoptionheader
 \jaoption{server}{s}
 {Server to receive jobs from.
 Defaults to localhost.}

--- a/requirements/customer/cli.tex
+++ b/requirements/customer/cli.tex
@@ -28,7 +28,7 @@ Commands, options, and valid targets are and options are specified in the follow
 
 Options can be added in the following ways:
 \begin{itemize}
-\item By supplying their names like "--<option\_x> --<option\_y>=2 --<option\_z>".
+\item By supplying their names like "-{}-option\_x -{}-option\_y=2 -{}-option\_z".
 \item By supplying their abbreviations like "-x -y 2 -z".
 \item By supplying their abbreviations like "-xz -y 2".
 \end{itemize}

--- a/requirements/customer/cli.tex
+++ b/requirements/customer/cli.tex
@@ -37,7 +37,7 @@ The available \textit{commands} are generally specific to the used component.
 Likewise, the available \textit{options} and \textit{targets} are generally specific to the commands of a used component.
 However, some commands and options are shared between components or commands.
 
-The JobAdder CLI ignores capitalization.
+The JobAdder CLI only uses lower-case letters.
 JobAdder CLI options override the values of configuration files.
 If no command is given, the general help text for the given component is printed out.
 \subsubsection{Shared Options}

--- a/requirements/customer/cli.tex
+++ b/requirements/customer/cli.tex
@@ -29,8 +29,8 @@ Commands, options, and valid targets are and options are specified in the follow
 Options can be added in the following ways:
 \begin{itemize}
 \item By supplying their names like "--<option\_x> --<option\_y>=2 --<option\_z>".
-%\item By supplying their abbreviations like "-x -y 2 -z".
-%\item By supplying their abbreviations like "-xz -y 2".
+\item By supplying their abbreviations like "-x -y 2 -z".
+\item By supplying their abbreviations like "-xz -y 2".
 \end{itemize}
 
 The available \textit{commands} are generally specific to the used component.

--- a/requirements/customer/cli.tex
+++ b/requirements/customer/cli.tex
@@ -98,5 +98,8 @@ In addition to the one below, options from add command can be used as constraint
 \jacommand{stop}{None}{Stops instances of the JobAdder server.}
 
 \subsubsection{Worker Client}
-\jacommand{start}{None}{Starts an instance of the JobAdder worker client.}
+\jacommand{start}{server}{Starts an instance of the JobAdder worker client.}
+\jaoption{server}{s}
+{Server to receive jobs from.
+Defaults to localhost.}
 \jacommand{stop}{None}{Stops instances of the JobAdder worker client.}

--- a/requirements/customer/cli.tex
+++ b/requirements/customer/cli.tex
@@ -56,7 +56,7 @@ If set to 0, no information is printed out.}
 \jacommand{add}
 {gpu, mount, name, priority, server, ram, threads}
 {Sends one or more job requests to the server.
-If targets are Docker containers the worker client simply runs the container.
+If targets are Docker containers the consists of simply running the container.
 If targets are configuration files with a specified terminal command the worker executes the given terminal command.
 Otherwise targets are interpreted as terminal commands}
 \jaoption{gpu}{g}{

--- a/requirements/customer/cli.tex
+++ b/requirements/customer/cli.tex
@@ -70,7 +70,7 @@ If set to a specific GPU model, informs the server that the job must be run on a
 {Human-readable name of the job.
 Defaults to user's name + job index}
 \jaoption{priority}{p}
-{Sets the priority of the job: Very high, high, medium, or low.
+{Sets the priority of the job: urgent, high, medium, or low.
 Defaults to medium.}
 \jaoption{server}{s}
 {Server to send the job request to.

--- a/requirements/customer/cli.tex
+++ b/requirements/customer/cli.tex
@@ -1,0 +1,102 @@
+\newcommand{\jacommand}[3]{
+
+\textsc{\large{\textbf{#1}}}
+\begin{itemize}
+\item[\textbf{Options:}] #2
+\item[\textbf{Effect:}] #3
+\end{itemize}
+}
+\newcommand{\jaoption}[3]{
+\begin{itemize}
+\item[] \textbf{#1} (#2)
+\item[\textbf{Effect:}] #3
+\end{itemize}
+}
+\subsection{Command Line Interface}
+All components of JobAdder are accessible through a command line interface (CLI).
+The command line interface on a machine with JobAdder installed has the following structure:
+\begin{equation}
+\text{<component name> <command> <options> <targets>},
+\end{equation}
+where the \textit{component name} can be any one of the following:
+\begin{itemize}
+\item \textbf{jobadder} to access the \textit{user client}.
+\item \textbf{jobcenter} to access the \textit{server}.
+\item \textbf{jobworker} to access the \textit{worker client}.
+\end{itemize}
+Commands, options, and valid targets are and options are specified in the following sections.
+
+Options can be added in the following ways:
+\begin{itemize}
+\item By supplying their names like "--<option\_x> --<option\_y>=2 --<option\_z>".
+%\item By supplying their abbreviations like "-x -y 2 -z".
+%\item By supplying their abbreviations like "-xz -y 2".
+\end{itemize}
+
+The available \textit{commands} are generally specific to the used component.
+Likewise, the available \textit{options} and \textit{targets} are generally specific to the commands of a used component.
+However, some commands and options are shared between components or commands.
+
+The JobAdder CLI ignores capitalization.
+JobAdder CLI options override the values of configuration files.
+If no command is given, the general help text for the given component is printed out.
+\subsubsection{Shared Options}
+\jaoption{config}{c}{Overrides the global configuration file with the given configuration file.}
+\jaoption{detach}{d}{Detaches the execution of the given command from the command line.}
+\jaoption{help}{h}{
+Prints out a list of the available commands. 
+When used in conjunction with a command:
+prints out more detailed information on the given command and a list of the available options.}
+\jaoption{verbose}{v}{
+Determines the amount of information printed out.
+If set to 2, detailed information is printed out.
+If set to 1, only high-level information is printed out (default).
+If set to 0, no information is printed out.}
+\subsubsection{User Client}
+\jacommand{add}
+{gpu, mount, name, priority, server, ram, threads}
+{Sends one or more job requests to the server.
+If targets are Docker containers the worker client simply runs the container.
+If targets are configuration files with a specified terminal command the worker executes the given terminal command.
+Otherwise targets are interpreted as terminal commands}
+\jaoption{gpu}{g}{
+If set to true, informs the server that the job requires a gpu.
+If set to a string that can be interpreted as VRAM amount, informs the server that a GPU with this amount of VRAM is required for the job.
+If set to a specific GPU model, informs the server that the job must be run on a machine with that GPU built in.
+}
+\jaoption{mount}{m}
+{Directories that need to be mounted onto the Docker container that the job is running in.}
+\jaoption{name}{n}
+{Human-readable name of the job.
+Defaults to user's name + job index}
+\jaoption{priority}{p}
+{Sets the priority of the job: Very high, high, medium, or low.
+Defaults to medium.}
+\jaoption{server}{s}
+{Server to send the job request to.
+Defaults to localhost.}
+\jaoption{ram}{r}
+{If set to a string that can be interpreted as RAM amount, informs the server that this amount of RAM is required for the job.}
+\jaoption{threads}{t}
+{If set to an integer, informs the server that this number of threads is required for the job.}
+
+\jacommand{pause}{None}{Pauses the job with the specified name.}
+
+\jacommand{query}{user}
+{Prints out information on running/queued/past jobs (specified by target).
+In addition to the one below, options from add command can be used as constraints.}
+\jaoption{after}{a}{Only return jobs added after the given point in time.}
+\jaoption{before}{b}{Only return jobs added before the given point in time.}
+\jaoption{user}{u}{Filter query by user that added the job.}
+
+\jacommand{resume}{None}{Resumes the job with the specified name.}
+
+\jacommand{stop}{None}{Stops the job with the specified name.}
+
+\subsubsection{Server}
+\jacommand{start}{None}{Starts an instance of the JobAdder server.}
+\jacommand{stop}{None}{Stops instances of the JobAdder server.}
+
+\subsubsection{Worker Client}
+\jacommand{start}{None}{Starts an instance of the JobAdder worker client.}
+\jacommand{stop}{None}{Stops instances of the JobAdder worker client.}

--- a/requirements/customer/cli.tex
+++ b/requirements/customer/cli.tex
@@ -43,7 +43,6 @@ JobAdder CLI options override the values of configuration files.
 If no command is given, the general help text for the given component is printed out.
 \subsubsection{Shared Options}
 \jaoption{config}{c}{Overrides the global configuration file with the given configuration file.}
-\jaoption{detach}{d}{Detaches the execution of the given command from the command line.}
 \jaoption{help}{h}{
 Prints out a list of the available commands. 
 When used in conjunction with a command:
@@ -52,15 +51,29 @@ prints out more detailed information on the given command and a list of the avai
 Determines the amount of information printed out.
 If set to 2, detailed information is printed out.
 If set to 1, only high-level information is printed out (default).
-If set to 0, no information is printed out.}
+If set to 0, no information is printed out.
+Note that this option affects both logs and command line output.
+}
 \subsubsection{User Client}
 \jacommand{add}
-{gpu, mount, name, priority, server, ram, threads}
+{attach, gpu, mount, name, priority, server, ram, threads}
 {Sends one or more job requests to the server.
 If targets are Docker containers the job consists of simply running the container.
 If targets are configuration files with a specified terminal command the job consists of running the specified terminal command.
-Otherwise targets are interpreted as terminal commands}
+Otherwise targets are interpreted as terminal commands.
+}
 \jaoptionheader
+\jaoption{attach}{a}{
+If set to true, attaches the user client command line to the command line output of the job:
+the command line output of the job is forwarded to the command line of the user client.
+The user client command line will be blocked until the job terminates.
+Incompatible with "block".
+}
+\jaoption{block}{b}{
+The user client command line will be blocked until the job terminates.
+The command line output of the job is \textbf{not} forwarded to the command line of the user client.
+Incompatible with "attach".
+}
 \jaoption{gpu}{g}{
 If set to true, informs the server that the job requires a gpu.
 If set to a string that can be interpreted as VRAM amount, informs the server that a GPU with this amount of VRAM is required for the job.

--- a/requirements/main.tex
+++ b/requirements/main.tex
@@ -1,7 +1,8 @@
 \documentclass[a4paper,10pt]{article}
+\usepackage[T1]{fontenc}
 \usepackage[utf8]{inputenc}
 \usepackage{graphicx}       % provides commands for including figures
-
+\usepackage{amsmath}
 
 %opening
 \title{JobAdder: Requirements}
@@ -14,6 +15,7 @@
 \input{customer/introduction}
 \input{customer/main}
 \input{customer/scheduling-algorithm}
+\input{customer/cli}
 \input{system/main}
 
 \end{document}


### PR DESCRIPTION
This PR adds a first draft for the envisioned command line interface.
CLI command and option entries are rather ugly as of right now; We should refactor their visuals at some point in the future.
(Refactoring visuals will be relatively easy because I defined LaTeX macros for adding commands and options.)

The CLI LaTeX file is currently located in the customer directory.
Should it be moved to the system directory?