### PR TITLE
Add table of contents and formatting improvements

### DIFF
--- a/requirements/.gitignore
+++ b/requirements/.gitignore
@@ -5,3 +5,5 @@
 *.glo
 *.ist
 *.log
+*.toc
+*.out

--- a/requirements/customer/cli.tex
+++ b/requirements/customer/cli.tex
@@ -41,7 +41,7 @@ However, some commands and options are shared between components or commands.
 The JobAdder CLI only uses lower-case letters.
 JobAdder CLI options override the values of configuration files.
 If no command is given, the general help text for the given component is printed out.
-\subsubsection{Shared Options}
+\subsection{Shared Options}
 \jaoption{config}{c}{Overrides the global configuration file with the given configuration file.}
 \jaoption{help}{h}{
 Prints out a list of the available commands. 
@@ -54,7 +54,7 @@ If set to 1, only high-level information is printed out (default).
 If set to 0, no information is printed out.
 Note that this option affects both logs and command line output.
 }
-\subsubsection{User Client}
+\subsection{User Client}
 \jacommand{add}
 {attach, gpu, mount, name, priority, server, ram, threads}
 {Sends one or more job requests to the server.
@@ -102,10 +102,10 @@ In addition to the one below, options from add command can be used as constraint
 \jaoption{before}{b}{Only return jobs added before the given point in time.}
 \jaoption{user}{u}{Filter query by user that added the job.}
 \jacommand{stop}{None}{Stops the job with the specified name.}
-\subsubsection{Server}
+\subsection{Server}
 \jacommand{start}{None}{Starts an instance of the JobAdder server.}
 \jacommand{stop}{None}{Stops instances of the JobAdder server.}
-\subsubsection{Worker Client}
+\subsection{Worker Client}
 \jacommand{start}{server}{Starts an instance of the JobAdder worker client.}
 \jaoptionheader
 \jaoption{server}{s}

--- a/requirements/customer/cli.tex
+++ b/requirements/customer/cli.tex
@@ -13,7 +13,7 @@
 \item \textbf{Effect:} #3
 \end{itemize}
 }
-\section{Command Line Interface}
+\chapter{Command Line Interface}
 All components of JobAdder are accessible through a command line interface (CLI).
 The command line interface on a machine with JobAdder installed has the following structure:
 \begin{equation}
@@ -41,7 +41,7 @@ However, some commands and options are shared between components or commands.
 The JobAdder CLI only uses lower-case letters.
 JobAdder CLI options override the values of configuration files.
 If no command is given, the general help text for the given component is printed out.
-\subsection{Shared Options}
+\section{Shared Options}
 \jaoption{config}{c}{Overrides the global configuration file with the given configuration file.}
 \jaoption{help}{h}{
 Prints out a list of the available commands. 
@@ -54,7 +54,7 @@ If set to 1, only high-level information is printed out (default).
 If set to 0, no information is printed out.
 Note that this option affects both logs and command line output.
 }
-\subsection{User Client}
+\section{User Client}
 \jacommand{add}
 {attach, gpu, mount, name, priority, server, ram, threads}
 {Sends one or more job requests to the server.
@@ -102,10 +102,10 @@ In addition to the one below, options from add command can be used as constraint
 \jaoption{before}{b}{Only return jobs added before the given point in time.}
 \jaoption{user}{u}{Filter query by user that added the job.}
 \jacommand{stop}{None}{Stops the job with the specified name.}
-\subsection{Server}
+\section{Server}
 \jacommand{start}{None}{Starts an instance of the JobAdder server.}
 \jacommand{stop}{None}{Stops instances of the JobAdder server.}
-\subsection{Worker Client}
+\section{Worker Client}
 \jacommand{start}{server}{Starts an instance of the JobAdder worker client.}
 \jaoptionheader
 \jaoption{server}{s}

--- a/requirements/customer/goals.tex
+++ b/requirements/customer/goals.tex
@@ -1,5 +1,5 @@
-\section{Purpose}
-  \subsection{Product Goal}
+\chapter{Purpose}
+  \section{Product Goal}
     JobAdder aims to facilitate and accelerate the execution of computationally
     expensive jobs in a cluster of work machines.
 
@@ -27,7 +27,7 @@
     cancel low-priority jobs manually. The scheduling algorithm also guarantees that
     every job is eventually run by automatically increasing its priority over time.
 
-  \subsection{Target Audience}
+  \section{Target Audience}
     The target audience mostly consists of groups of users with access to several
     work machines. This includes companies, academic institutions and computing
     centers. These users usually need remote machines to run their jobs due to high

--- a/requirements/customer/introduction.tex
+++ b/requirements/customer/introduction.tex
@@ -1,5 +1,4 @@
-\section{Introduction}
-
+\chapter{Introduction}
 The JobAdder project enables users to remotely execute resource-intensive tasks on a dedicated cluster of work machines.
 Tasks are being distributed to work machines automatically.
 The distribution reduces task execution times and peak system loads by better utilizing the available hardware.

--- a/requirements/customer/main.tex
+++ b/requirements/customer/main.tex
@@ -1,5 +1,5 @@
-\section{Customer requirements}
-\subsection{General}
+\chapter{Customer requirements}
+\section{General}
 \begin{enumerate}
  \item JA must provide a central server that assigns user jobs to work machines.
  \item JA must provide a user client (UC) that transmits a user's job request to the central server.
@@ -7,13 +7,13 @@
  \item All components of JA must work under the following Linux distributions: Ubuntu 18.04, CentOS 7.
  \item Users must be notified when one of their jobs terminates.
 \end{enumerate}
-\subsubsection{Technical requirements}
+\subsection{Technical requirements}
 \begin{enumerate}
  \item JA must follow an object-oriented design.
  \item JA must be implemented in Python 3.
  \item All JA references and methods must have consistent Python type hints.
 \end{enumerate}
-\subsection{Optional}
+\section{Optional}
 \begin{enumerate}
  \item Blocking mode: wait for the job to finish before client returns.
  \item Path translation: handle different mount point locations.

--- a/requirements/customer/product-environment.tex
+++ b/requirements/customer/product-environment.tex
@@ -1,23 +1,23 @@
-\section{Product Environment}
-  \subsection{User Client}
-    \subsubsection{Hardware Requirements}
+\chapter{Product Environment}
+  \section{User Client}
+    \subsection{Hardware Requirements}
       \begin{itemize}
       \item A connection to the central server.
       \item 2 MB of storage space and an additional 100 MB per image.
       \end{itemize}
-    \subsubsection{Software Requirements}
+    \subsection{Software Requirements}
       \begin{itemize}
       \item Python 3.
     \end{itemize}
 
-  \subsection{Central Server}
-    \subsubsection{Hardware Requirements}  
+  \section{Central Server}
+    \subsection{Hardware Requirements}
     \begin{itemize}
       \item 500 MB of storage space.
       \item 2 GB of RAM.
       \item One physical CPU core.
     \end{itemize}
-    \subsubsection{Software Requirements}  
+    \subsection{Software Requirements}
     \begin{itemize}
       \item Linux Ubuntu 18.04 or newer, or CentOS 7.5 or newer.
       \item MySQL Database Server version 8.0 or newer.
@@ -26,8 +26,8 @@
       \item Python 3.
     \end{itemize}
 
-  \subsection{Working Machine Client}
-    \subsubsection{Hardware Requirements}
+  \section{Working Machine Client}
+    \subsection{Hardware Requirements}
       In addition to the hardware required to run a job, our worker client would need the following resources:
     \begin{itemize}
       \item A connection to a LAN.
@@ -35,10 +35,10 @@
       \item 3 GB of available disk space.
       \item Static IP Address.
     \end{itemize}
-    \subsubsection{Software Requirements}  
+    \subsection{Software Requirements}
     \begin{itemize}
       \item Linux kernel version 3.10 or higher.
       \item CS Docker engine 1.13, EE Deamon 17.03 and higher.
       \item Python 3.
     \end{itemize}
-    
+

--- a/requirements/customer/scheduling-algorithm.tex
+++ b/requirements/customer/scheduling-algorithm.tex
@@ -1,4 +1,4 @@
-\section{Scheduling Algorithm}
+\chapter{Scheduling Algorithm}
 This section describes how the central server distributes jobs to work machines: the \textit{scheduling algorithm}.
 Put briefly, the scheduling algorithm takes a list of jobs and decides which ones to run on the available work machines.
 The scheduling algorithm has the following goals:

--- a/requirements/main.tex
+++ b/requirements/main.tex
@@ -14,15 +14,40 @@
 
 \begin{document}
 
+% Macro for table of contents from sections instead of chapters
+% Taken from https://tex.stackexchange.com/questions/246354/change-toc-to-section-instead-of-chapter
+\makeatletter
+\renewcommand\tableofcontents{%
+    \if@twocolumn
+      \@restonecoltrue\onecolumn
+    \else
+      \@restonecolfalse
+    \fi
+    \section*{\contentsname
+        \@mkboth{%
+           \MakeUppercase\contentsname}{\MakeUppercase\contentsname}}%
+    \@starttoc{toc}%
+    \if@restonecol\twocolumn\fi
+    }
+\makeatother
+
 \maketitle
+\tableofcontents
+\newpage
 
 \input{customer/introduction}
 \input{customer/goals}
+\newpage
 \input{customer/main}
+\newpage
 \input{customer/product-environment}
+\newpage
 \input{customer/scheduling-algorithm}
+\newpage
 \input{customer/cli}
+\newpage
 \input{system/main}
 
+\newpage
 \printunsrtglossaries
 \end{document}

--- a/requirements/main.tex
+++ b/requirements/main.tex
@@ -1,4 +1,4 @@
-\documentclass[a4paper,10pt]{article}
+\documentclass[a4paper,10pt]{scrreprt}
 \usepackage[T1]{fontenc}
 \usepackage[utf8]{inputenc}
 \usepackage[nonumberlist,nopostdot]{glossaries-extra}     % provides glossary commands
@@ -14,38 +14,16 @@
 
 \begin{document}
 
-% Macro for table of contents from sections instead of chapters
-% Taken from https://tex.stackexchange.com/questions/246354/change-toc-to-section-instead-of-chapter
-\makeatletter
-\renewcommand\tableofcontents{%
-    \if@twocolumn
-      \@restonecoltrue\onecolumn
-    \else
-      \@restonecolfalse
-    \fi
-    \section*{\contentsname
-        \@mkboth{%
-           \MakeUppercase\contentsname}{\MakeUppercase\contentsname}}%
-    \@starttoc{toc}%
-    \if@restonecol\twocolumn\fi
-    }
-\makeatother
-
 \maketitle
 \tableofcontents
 \newpage
 
 \input{customer/introduction}
 \input{customer/goals}
-\newpage
 \input{customer/main}
-\newpage
 \input{customer/product-environment}
-\newpage
 \input{customer/scheduling-algorithm}
-\newpage
 \input{customer/cli}
-\newpage
 \input{system/main}
 
 \newpage

--- a/requirements/system/main.tex
+++ b/requirements/system/main.tex
@@ -1,14 +1,11 @@
-\section{Central server}
+\chapter{Central server}
 \input{system/server/functional}
 \input{system/server/non-functional}
 \input{system/server/product-data}
 
-\newpage
 \input{system/user-client}
-\newpage
 \input{system/work-machine-client}
 
-\newpage
-\section{Usage}
+\chapter{Usage}
 \input{system/usage/use-cases}
 \input{system/usage/usage-scenarios}

--- a/requirements/system/main.tex
+++ b/requirements/system/main.tex
@@ -3,9 +3,12 @@
 \input{system/server/non-functional}
 \input{system/server/product-data}
 
+\newpage
 \input{system/user-client}
+\newpage
 \input{system/work-machine-client}
 
+\newpage
 \section{Usage}
 \input{system/usage/use-cases}
 \input{system/usage/usage-scenarios}

--- a/requirements/system/server/functional.tex
+++ b/requirements/system/server/functional.tex
@@ -1,5 +1,5 @@
-\subsection{Functional requirements}
-\subsubsection{Main features}
+\section{Functional requirements}
+\subsection{Main features}
 \begin{enumerate}
   \item[CSF10] The central server shall distribute \glspl{job}
     among the available work machines using the scheduling algorithm.

--- a/requirements/system/server/non-functional.tex
+++ b/requirements/system/server/non-functional.tex
@@ -1,4 +1,4 @@
-\subsection{Non-functional requirements}
+\section{Non-functional requirements}
 \begin{enumerate}
   \item[CSN10] The central server must be able to handle at least 20 connected work machines at any given time.
   \item[CSN20] The central server must be able to handle at least 100 concurrent jobs.

--- a/requirements/system/server/product-data.tex
+++ b/requirements/system/server/product-data.tex
@@ -1,4 +1,4 @@
-\subsection{Product data}
+\section{Product data}
 \begin{enumerate}
   \item[CSP10] The central server shall store past, running and scheduled \glspl{job} in a persistent database.
   \item[CSP20] The central server shall store the assigned work machine for each stored \gls{job} from CSP10.

--- a/requirements/system/usage/usage-scenarios.tex
+++ b/requirements/system/usage/usage-scenarios.tex
@@ -1,4 +1,4 @@
-\subsubsection{Usage scenarios}
+\section{Usage scenarios}
 \begin{enumerate}
   \item High priority job.
   \begin{itemize}

--- a/requirements/system/usage/use-cases.tex
+++ b/requirements/system/usage/use-cases.tex
@@ -1,4 +1,4 @@
-\subsection{Use cases}
+\section{Use cases}
 \begin{enumerate}
   \item Add job.
   \begin{itemize}

--- a/requirements/system/user-client.tex
+++ b/requirements/system/user-client.tex
@@ -1,4 +1,4 @@
-\section{User Client}
+\chapter{User Client}
 \begin{enumerate}
  \item UCs must be accessible through a CLI.
  \item UCs must provide to the user the same functionality as if the user was working directly on a work machine.

--- a/requirements/system/work-machine-client.tex
+++ b/requirements/system/work-machine-client.tex
@@ -1,6 +1,6 @@
-\section{Worker client(WC)}
-  \subsection{Functional requirements}
-    \subsubsection{Main features}
+\chapter{Worker client(WC)}
+  \section{Functional requirements}
+    \subsection{Main features}
     \begin{enumerate}
       \item[WCF10] On startup, WC shall connect to the server and report its hardware capabilities.
       \item[WCF20] WC must be able to receive commands from the central server.
@@ -17,14 +17,14 @@
       \item[WCF60] WC shall notify the server whenever a job is completed.
     \end{enumerate}
 
-    \subsubsection{Optional features}
+    \subsection{Optional features}
       \begin{enumerate}
         \item[WCFO10] WC shall notify the server periodically on the progress of the job.
         \item[WCFO20] WC shall decide what kind of local storage to use for each job. (RAM, SSD or HDD).
         \item[WCFO30] WC shall estimate the time of arrival of a job.
       \end{enumerate}
 
-  \subsection{Product Data}
+  \section{Product Data}
   \begin{enumerate}
     \item[WCP10] Docker containers for all the jobs running on this machine.
     \item[WCP20] Results of the jobs running on this machine.


### PR DESCRIPTION
I wanted to create a table of contents at the beginning of our documents, and also added `\newpage` after most sections. To me, it makes sense that each non-trivial section begins at a new page.

Also, I noticed that in CLI we use `subsubsection` directly after `section` which doesn't make sense.