### PR TITLE
Sequence diagrams for Proxy objects

### DIFF
--- a/design/sequence/proxy-continuous.puml
+++ b/design/sequence/proxy-continuous.puml
@@ -6,7 +6,7 @@
 box "Local components"
     boundary Boundary
     participant "command:Command" as Command
-    participant ":SingleMessageProxy" as Proxy
+    participant ":ContinuousProxy" as Proxy
     participant ":SSHConnection" as SSHConnection
     participant "response:Response" as Response
 end box

--- a/design/sequence/proxy-continuous.puml
+++ b/design/sequence/proxy-continuous.puml
@@ -14,7 +14,7 @@ end box
 Boundary -> Proxy ++ : CommandMessage
 'Proxy -> SSHConnection ** : Create
 Proxy -> SSHConnection ++ : CommandMessage
-SSHConnection -> RemoteComponent ++ : YAML
+SSHConnection -> RemoteComponent ++ : Call via shell, YAML as argument
 RemoteComponent -> RemoteComponent : Execute command
 SSHConnection <- RemoteComponent -- : YAML
 SSHConnection -> ResponseMessage ** : Create

--- a/design/sequence/proxy-continuous.puml
+++ b/design/sequence/proxy-continuous.puml
@@ -14,9 +14,11 @@ end box
 Boundary -> Proxy ++ : CommandMessage
 'Proxy -> SSHConnection ** : Create
 Proxy -> SSHConnection ++ : CommandMessage
-SSHConnection -> RemoteComponent ++ : Call via shell, YAML as argument
-RemoteComponent -> RemoteComponent : Execute command
-SSHConnection <- RemoteComponent -- : YAML
+SSHConnection -> Remote ** : Call via shell, YAML as argument
+activate Remote
+Remote -> Remote : Execute command
+SSHConnection <- Remote -- : ResponseMessage as YAML
+destroy Remote
 SSHConnection -> ResponseMessage ** : Create
 Proxy <- SSHConnection -- : ResponseMessage
 'Proxy -> SSHConnection !!

--- a/design/sequence/proxy-continuous.puml
+++ b/design/sequence/proxy-continuous.puml
@@ -1,0 +1,27 @@
+@startuml
+
+'This file is the same as proxy-one-message.puml except the SSHConnection is continuous 
+'instead of created/destroyed for each Message.
+
+box "Local components"
+    boundary Boundary
+    participant CommandMessage
+    participant ContinuousProxy as Proxy
+    participant SSHConnection
+    participant ResponseMessage
+end box
+
+Boundary -> Proxy ++ : CommandMessage
+'Proxy -> SSHConnection ** : Create
+Proxy -> SSHConnection ++ : CommandMessage
+SSHConnection -> RemoteComponent ++ : YAML
+RemoteComponent -> RemoteComponent : Execute command
+SSHConnection <- RemoteComponent -- : YAML
+SSHConnection -> ResponseMessage ** : Create
+Proxy <- SSHConnection -- : ResponseMessage
+'Proxy -> SSHConnection !!
+Boundary <- Proxy -- : ResponseMessage
+
+destroy ResponseMessage
+
+@enduml

--- a/design/sequence/proxy-continuous.puml
+++ b/design/sequence/proxy-continuous.puml
@@ -5,25 +5,28 @@
 
 box "Local components"
     boundary Boundary
-    participant Command
-    participant ContinuousProxy as Proxy
-    participant SSHConnection
-    participant Response
+    participant "command:Command" as Command
+    participant ":SingleMessageProxy" as Proxy
+    participant ":SSHConnection" as SSHConnection
+    participant "response:Response" as Response
 end box
+participant ":Remote" as Remote
 
-Boundary -> Proxy ++ : Command
+Boundary -> Proxy ++ : command
 'Proxy -> SSHConnection ** : Create
-Proxy -> SSHConnection ++ : Command
-SSHConnection -> Remote ** : Call via shell, YAML as argument
+Proxy -> SSHConnection ++ : command
+SSHConnection --> Remote ** : Call via SSH
 activate Remote
-... Remote processes Command, sets environment variable for Response ...
-SSHConnection <- Remote -- : Return
-destroy Remote
-SSHConnection -> SSHConnection: Read environment variable
+Remote -> Remote : Read from stdin
+SSHConnection --> Remote : Write command.serialize() on stdin
+SSHConnection -> Remote : Read from stdout
+... Remote processes command ...
+Remote --> Remote : Write response as \nYAML to stdout
 SSHConnection -> Response ** : Create
-Proxy <- SSHConnection -- : Response
-'Proxy -> SSHConnection !!
-Boundary <- Proxy -- : Response
+destroy Remote
+Proxy <-- SSHConnection -- : response
+'Proxy -> SSHConnection !! : Close
+Boundary <-- Proxy -- : response
 
 destroy Response
 

--- a/design/sequence/proxy-continuous.puml
+++ b/design/sequence/proxy-continuous.puml
@@ -5,25 +5,26 @@
 
 box "Local components"
     boundary Boundary
-    participant CommandMessage
+    participant Command
     participant ContinuousProxy as Proxy
     participant SSHConnection
-    participant ResponseMessage
+    participant Response
 end box
 
-Boundary -> Proxy ++ : CommandMessage
+Boundary -> Proxy ++ : Command
 'Proxy -> SSHConnection ** : Create
-Proxy -> SSHConnection ++ : CommandMessage
+Proxy -> SSHConnection ++ : Command
 SSHConnection -> Remote ** : Call via shell, YAML as argument
 activate Remote
-Remote -> Remote : Execute command
-SSHConnection <- Remote -- : ResponseMessage as YAML
+... Remote processes Command, sets environment variable for Response ...
+SSHConnection <- Remote -- : Return
 destroy Remote
-SSHConnection -> ResponseMessage ** : Create
-Proxy <- SSHConnection -- : ResponseMessage
+SSHConnection -> SSHConnection: Read environment variable
+SSHConnection -> Response ** : Create
+Proxy <- SSHConnection -- : Response
 'Proxy -> SSHConnection !!
-Boundary <- Proxy -- : ResponseMessage
+Boundary <- Proxy -- : Response
 
-destroy ResponseMessage
+destroy Response
 
 @enduml

--- a/design/sequence/proxy-one-message.puml
+++ b/design/sequence/proxy-one-message.puml
@@ -2,25 +2,26 @@
 
 box "Local components"
     boundary Boundary
-    participant CommandMessage
+    participant Command
     participant SingleMessageProxy as Proxy
     participant SSHConnection
-    participant ResponseMessage
+    participant Response
 end box
 
-Boundary -> Proxy ++ : CommandMessage
+Boundary -> Proxy ++ : Command
 Proxy -> SSHConnection ** : Create
-Proxy -> SSHConnection ++ : CommandMessage
+Proxy -> SSHConnection ++ : Command
 SSHConnection -> Remote ** : Call via shell, YAML as argument
 activate Remote
-Remote -> Remote : Execute command
-SSHConnection <- Remote -- : ResponseMessage as YAML
+... Remote processes Command, sets environment variable for Response ...
+SSHConnection <- Remote -- : Return
 destroy Remote
-SSHConnection -> ResponseMessage ** : Create
-Proxy <- SSHConnection -- : ResponseMessage
+SSHConnection -> SSHConnection: Read environment variable
+SSHConnection -> Response ** : Create
+Proxy <- SSHConnection -- : Response
 Proxy -> SSHConnection !!
-Boundary <- Proxy -- : ResponseMessage
+Boundary <- Proxy -- : Response
 
-destroy ResponseMessage
+destroy Response
 
 @enduml

--- a/design/sequence/proxy-one-message.puml
+++ b/design/sequence/proxy-one-message.puml
@@ -1,0 +1,24 @@
+@startuml
+
+box "Local components"
+    boundary Boundary
+    participant CommandMessage
+    participant SingleMessageProxy as Proxy
+    participant SSHConnection
+    participant ResponseMessage
+end box
+
+Boundary -> Proxy ++ : CommandMessage
+Proxy -> SSHConnection ** : Create
+Proxy -> SSHConnection ++ : CommandMessage
+SSHConnection -> RemoteComponent ++ : YAML
+RemoteComponent -> RemoteComponent : Execute command
+SSHConnection <- RemoteComponent -- : YAML
+SSHConnection -> ResponseMessage ** : Create
+Proxy <- SSHConnection -- : ResponseMessage
+Proxy -> SSHConnection !!
+Boundary <- Proxy -- : ResponseMessage
+
+destroy ResponseMessage
+
+@enduml

--- a/design/sequence/proxy-one-message.puml
+++ b/design/sequence/proxy-one-message.puml
@@ -2,25 +2,28 @@
 
 box "Local components"
     boundary Boundary
-    participant Command
-    participant SingleMessageProxy as Proxy
-    participant SSHConnection
-    participant Response
+    participant "command:Command" as Command
+    participant ":SingleMessageProxy" as Proxy
+    participant ":SSHConnection" as SSHConnection
+    participant "response:Response" as Response
 end box
+participant ":Remote" as Remote
 
-Boundary -> Proxy ++ : Command
+Boundary -> Proxy ++ : command
 Proxy -> SSHConnection ** : Create
-Proxy -> SSHConnection ++ : Command
-SSHConnection -> Remote ** : Call via shell, YAML as argument
+Proxy -> SSHConnection ++ : command
+SSHConnection --> Remote ** : Call via SSH
 activate Remote
-... Remote processes Command, sets environment variable for Response ...
-SSHConnection <- Remote -- : Return
-destroy Remote
-SSHConnection -> SSHConnection: Read environment variable
+Remote -> Remote : Read from stdin
+SSHConnection --> Remote : Write command.serialize() on stdin
+SSHConnection -> Remote : Read from stdout
+... Remote processes command ...
+Remote --> Remote : Write response as \nYAML to stdout
 SSHConnection -> Response ** : Create
-Proxy <- SSHConnection -- : Response
-Proxy -> SSHConnection !!
-Boundary <- Proxy -- : Response
+destroy Remote
+Proxy <-- SSHConnection -- : response
+Proxy -> SSHConnection !! : Close
+Boundary <-- Proxy -- : response
 
 destroy Response
 

--- a/design/sequence/proxy-one-message.puml
+++ b/design/sequence/proxy-one-message.puml
@@ -11,9 +11,11 @@ end box
 Boundary -> Proxy ++ : CommandMessage
 Proxy -> SSHConnection ** : Create
 Proxy -> SSHConnection ++ : CommandMessage
-SSHConnection -> RemoteComponent ++ : Call via shell, YAML as argument
-RemoteComponent -> RemoteComponent : Execute command
-SSHConnection <- RemoteComponent -- : YAML
+SSHConnection -> Remote ** : Call via shell, YAML as argument
+activate Remote
+Remote -> Remote : Execute command
+SSHConnection <- Remote -- : ResponseMessage as YAML
+destroy Remote
 SSHConnection -> ResponseMessage ** : Create
 Proxy <- SSHConnection -- : ResponseMessage
 Proxy -> SSHConnection !!

--- a/design/sequence/proxy-one-message.puml
+++ b/design/sequence/proxy-one-message.puml
@@ -11,7 +11,7 @@ end box
 Boundary -> Proxy ++ : CommandMessage
 Proxy -> SSHConnection ** : Create
 Proxy -> SSHConnection ++ : CommandMessage
-SSHConnection -> RemoteComponent ++ : YAML
+SSHConnection -> RemoteComponent ++ : Call via shell, YAML as argument
 RemoteComponent -> RemoteComponent : Execute command
 SSHConnection <- RemoteComponent -- : YAML
 SSHConnection -> ResponseMessage ** : Create

--- a/design/sequence/remote.puml
+++ b/design/sequence/remote.puml
@@ -4,7 +4,7 @@ participant Proxy
 
 box "Local components"
     participant Remote
-    participant MessageHandler
+    participant CommandHandler
     participant YAMLReader
     participant Command
     participant Response
@@ -12,18 +12,18 @@ end box
 
 Proxy -> Remote ** : Call via shell, YAML as argument
 activate Remote
-Remote --> MessageHandler ++ : Send Command as YAML via socket
+Remote --> CommandHandler ++ : Send Command as YAML via socket
 Remote -> Remote : Listen for response on socket
-MessageHandler -> YAMLReader ++ : Command as YAML
+CommandHandler -> YAMLReader ++ : Command as YAML
 YAMLReader -> Command ** : Create
-MessageHandler <- YAMLReader -- : Command
-MessageHandler -> MessageHandler : Execute command
-MessageHandler -> Response ** : Create
-MessageHandler --> Remote : Send Response as YAML via socket
+CommandHandler <- YAMLReader -- : Command
+CommandHandler -> CommandHandler : Execute command
+CommandHandler -> Response ** : Create
+CommandHandler --> Remote : Send Response as YAML via socket
 destroy Command
 destroy Response
-MessageHandler -> MessageHandler : Listen for more Messages
-deactivate MessageHandler
+CommandHandler -> CommandHandler : Listen for more Messages
+deactivate CommandHandler
 Remote -> Remote : Set environment variable \n with Response YAML string
 Proxy <- Remote -- : Return
 destroy Remote

--- a/design/sequence/remote.puml
+++ b/design/sequence/remote.puml
@@ -3,28 +3,33 @@
 participant Proxy
 
 box "Local components"
-    participant Remote
-    participant CommandHandler
-    participant YAMLReader
-    participant Command
-    participant Response
+    participant ":Remote" as Remote
+    participant ":CommandHandler" as CommandHandler
+    participant ":YAMLReader" as YAMLReader
+    participant "command:Command" as Command
+    participant "response:Response" as Response
 end box
 
-Proxy -> Remote ** : Call via shell, YAML as argument
+activate Proxy
+Proxy -> Remote ** : Call via SSH
 activate Remote
-Remote --> CommandHandler ++ : Send Command as YAML via socket
+Remote -> Remote : Read from stdin
+Proxy --> Remote : Write command as \nYAML to stdin
+Proxy -> Remote : Read from stdout
+Remote --> CommandHandler ++ : Send command as YAML via socket
 Remote -> Remote : Listen for response on socket
-CommandHandler -> YAMLReader ++ : Command as YAML
+CommandHandler -> YAMLReader ++ : command as YAML
 YAMLReader -> Command ** : Create
-CommandHandler <- YAMLReader -- : Command
-CommandHandler -> CommandHandler : Execute command
+CommandHandler <- YAMLReader -- : command
+CommandHandler -> Command ++ : execute()
+... command does something ...
+CommandHandler <-- Command -- 
 CommandHandler -> Response ** : Create
-CommandHandler --> Remote : Send Response as YAML via socket
+CommandHandler --> Remote : Send response as YAML via socket
+CommandHandler -> CommandHandler : Listen for more Commands
 destroy Command
 destroy Response
-CommandHandler -> CommandHandler : Listen for more Messages
 deactivate CommandHandler
-Remote -> Remote : Set environment variable \n with Response YAML string
-Proxy <- Remote -- : Return
+Remote -> Remote : Write response.serialize() to stdin
 destroy Remote
 @enduml

--- a/design/sequence/remote.puml
+++ b/design/sequence/remote.puml
@@ -5,7 +5,6 @@ participant Proxy
 box "Local components"
     participant ":Remote" as Remote
     participant ":CommandHandler" as CommandHandler
-    participant ":YAMLReader" as YAMLReader
     participant "command:Command" as Command
     participant "response:Response" as Response
 end box
@@ -18,9 +17,7 @@ Proxy --> Remote : Write command as \nYAML to stdin
 Proxy -> Remote : Read from stdout
 Remote --> CommandHandler ++ : Send command as YAML via socket
 Remote -> Remote : Listen for response on socket
-CommandHandler -> YAMLReader ++ : command as YAML
-YAMLReader -> Command ** : Create
-CommandHandler <- YAMLReader -- : command
+CommandHandler -> Command ** : Create from YAML
 CommandHandler -> Command ++ : execute()
 ... command does something ...
 CommandHandler <-- Command -- 
@@ -30,6 +27,6 @@ CommandHandler -> CommandHandler : Listen for more Commands
 destroy Command
 destroy Response
 deactivate CommandHandler
-Remote -> Remote : Write response.serialize() to stdin
+Remote -> Remote : Write response as YAML to stdout
 destroy Remote
 @enduml

--- a/design/sequence/remote.puml
+++ b/design/sequence/remote.puml
@@ -9,13 +9,17 @@ box "Local components"
     participant ResponseMessage
 end box
 
-Proxy -> Remote ++ : Call via shell, YAML as argument
+Proxy -> Remote ** : Call via shell, YAML as argument
+activate Remote
+Remote -> YAMLReader ** : Create
 Remote -> YAMLReader ++ : YAML
 YAMLReader -> CommandMessage ** : Create
 Remote <- YAMLReader -- : CommandMessage
 Remote -> Remote : Execute command
 Remote -> ResponseMessage ** : Create
 Proxy <- Remote -- : ResponseMessage as YAML
+destroy Remote
+destroy YAMLReader
 destroy CommandMessage
 destroy ResponseMessage
 @enduml

--- a/design/sequence/remote.puml
+++ b/design/sequence/remote.puml
@@ -4,22 +4,27 @@ participant Proxy
 
 box "Local components"
     participant Remote
+    participant MessageHandler
     participant YAMLReader
-    participant CommandMessage
-    participant ResponseMessage
+    participant Command
+    participant Response
 end box
 
 Proxy -> Remote ** : Call via shell, YAML as argument
 activate Remote
-Remote -> YAMLReader ** : Create
-Remote -> YAMLReader ++ : YAML
-YAMLReader -> CommandMessage ** : Create
-Remote <- YAMLReader -- : CommandMessage
-Remote -> Remote : Execute command
-Remote -> ResponseMessage ** : Create
-Proxy <- Remote -- : ResponseMessage as YAML
+Remote --> MessageHandler ++ : Send Command as YAML via socket
+Remote -> Remote : Listen for response on socket
+MessageHandler -> YAMLReader ++ : Command as YAML
+YAMLReader -> Command ** : Create
+MessageHandler <- YAMLReader -- : Command
+MessageHandler -> MessageHandler : Execute command
+MessageHandler -> Response ** : Create
+MessageHandler --> Remote : Send Response as YAML via socket
+destroy Command
+destroy Response
+MessageHandler -> MessageHandler : Listen for more Messages
+deactivate MessageHandler
+Remote -> Remote : Set environment variable \n with Response YAML string
+Proxy <- Remote -- : Return
 destroy Remote
-destroy YAMLReader
-destroy CommandMessage
-destroy ResponseMessage
 @enduml

--- a/design/sequence/remote.puml
+++ b/design/sequence/remote.puml
@@ -9,8 +9,7 @@ box "Local components"
     participant ResponseMessage
 end box
 
-Proxy -> Remote : CommandMessage as YAML
-Proxy -> Remote ++ : Execute via shell
+Proxy -> Remote ++ : Call via shell, YAML as argument
 Remote -> YAMLReader ++ : YAML
 YAMLReader -> CommandMessage ** : Create
 Remote <- YAMLReader -- : CommandMessage

--- a/design/sequence/remote.puml
+++ b/design/sequence/remote.puml
@@ -1,0 +1,22 @@
+@startuml
+
+participant Proxy
+
+box "Local components"
+    participant Remote
+    participant YAMLReader
+    participant CommandMessage
+    participant ResponseMessage
+end box
+
+Proxy -> Remote : CommandMessage as YAML
+Proxy -> Remote ++ : Execute via shell
+Remote -> YAMLReader ++ : YAML
+YAMLReader -> CommandMessage ** : Create
+Remote <- YAMLReader -- : CommandMessage
+Remote -> Remote : Execute command
+Remote -> ResponseMessage ** : Create
+Proxy <- Remote -- : ResponseMessage as YAML
+destroy CommandMessage
+destroy ResponseMessage
+@enduml


### PR DESCRIPTION
This PR adds sequence diagrams for Proxy objects.
Proxy objects implement the proxy design pattern.
They serve as an interface to a remote component and hide the specifics of network connections from other components.
This PR adds sequence diagrams for the following three cases:
* A Proxy that creates and destroys a new SSHConnection for each Command (user client -> server).
* A Proxy that creates a continuous SSHConnection that is used for all Commands (server -> worker client).
* A Remote that a proxy can connect to to transmit Commands.

Proxy for one Message:
![proxy-one-message](https://user-images.githubusercontent.com/18492268/70472029-b1fdb200-1ace-11ea-9e06-ecd41ecdb680.png)

Proxy for continuous use:
![proxy-continuous](https://user-images.githubusercontent.com/18492268/70849914-0add9980-1e85-11ea-994f-07ea516be7d3.png)

Remote:
![remote](https://user-images.githubusercontent.com/18492268/70861002-ad028d80-1f28-11ea-9040-68833332a205.png)
